### PR TITLE
Ensure xz-utils exists on the image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ EXPOSE 80
 
 ENV PROGET_VERSION 4.7.12
 
+RUN apt-get update && apt-get install xz-utils
+
 RUN mkdir -p /usr/local/proget && curl "https://s3.amazonaws.com/cdn.inedo.com/downloads/proget-linux/ProGet.$PROGET_VERSION.tar.xz" | tar xvJC /usr/local/proget
 
 ENV PROGET_DATABASE "Server=proget-postgres; Database=postgres; User Id=postgres; Password=;"


### PR DESCRIPTION
This pull request ensures xz-utils exists before trying to unpack proget. It appears the base mono image no longer includes these tools.